### PR TITLE
Add icons for Android

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,7 +9,7 @@ import "react-native-gesture-handler"
 import { keys } from "./src/Constants";
 import styles from "./src/Styles";
 import epilogueStorage from "./src/Storage";
-import { SFSymbol } from "./src/SFSymbols";
+import { Icon } from "./src/Icon";
 
 import { HomeScreen } from "./src/HomeScreen";
 import { BookDetailsScreen } from "./src/BookDetailsScreen";
@@ -55,12 +55,12 @@ const App: () => Node = () => {
   					headerTitle: "",
   					headerLeft: () => (
   						<Pressable onPress={() => { navigation.goBack(); }}>
-                <SFSymbol name="chevron.left" scale="large" color={is_dark ? "#FFFFFF" : "#337AB7"} size={16} resizeMode="center" style={styles.navbarBackIcon} />                
+                          <Icon name="navbar-back" color={is_dark ? "#FFFFFF" : "#337AB7"} size={16} style={styles.navbarBackIcon} />
   						</Pressable>
   					),
   					headerRight: () => (
               <Pressable onPress={() => { navigation.navigate("Post"); }}>
-                <SFSymbol name="square.and.pencil" scale="large" color={is_dark ? "#FFFFFF" : "#337AB7"} size={16} resizeMode="center" style={styles.navbarNewIcon} accessibilityLabel="new post" />
+                <Icon name="publish" color={is_dark ? "#FFFFFF" : "#337AB7"} size={16} style={styles.navbarNewIcon} accessibilityLabel="new post" />
               </Pressable>
   					)
   				})} />
@@ -70,7 +70,7 @@ const App: () => Node = () => {
             headerTitle: "",
             headerLeft: () => (
               <Pressable onPress={() => { navigation.goBack(); }}>
-                <SFSymbol name="xmark" scale="large" color={is_dark ? "#FFFFFF" : "#337AB7"} size={16} resizeMode="center" style={is_dark ? [ styles.navbarCloseIcon, styles.dark.navbarCloseIcon ] : styles.navbarCloseIcon} />                         
+                <Icon name="close" color={is_dark ? "#FFFFFF" : "#337AB7"} size={16} style={is_dark ? [ styles.navbarCloseIcon, styles.dark.navbarCloseIcon ] : styles.navbarCloseIcon} />
               </Pressable>
             ),
             headerRight: () => (
@@ -91,7 +91,7 @@ const App: () => Node = () => {
             headerTitle: "Blogs",
             headerLeft: () => (
               <Pressable onPress={() => { navigation.goBack(); }}>
-                <SFSymbol name="xmark" scale="large" color={is_dark ? "#FFFFFF" : "#337AB7"} size={16} resizeMode="center" style={is_dark ? [ styles.navbarCloseIcon, styles.dark.navbarCloseIcon ] : styles.navbarCloseIcon} />                         
+                <Icon name="close" color={is_dark ? "#FFFFFF" : "#337AB7"} size={16} style={is_dark ? [ styles.navbarCloseIcon, styles.dark.navbarCloseIcon ] : styles.navbarCloseIcon} />
               </Pressable>
             )
           })} />
@@ -99,7 +99,7 @@ const App: () => Node = () => {
             headerTitle: "",
             headerLeft: () => (
               <Pressable onPress={() => { navigation.goBack(); }}>
-                <SFSymbol name="xmark" scale="large" color={is_dark ? "#FFFFFF" : "#337AB7"} size={16} resizeMode="center" style={is_dark ? [ styles.navbarCloseIcon, styles.dark.navbarCloseIcon ] : styles.navbarCloseIcon} />                         
+                <Icon name="close" color={is_dark ? "#FFFFFF" : "#337AB7"} size={16} style={is_dark ? [ styles.navbarCloseIcon, styles.dark.navbarCloseIcon ] : styles.navbarCloseIcon} />
               </Pressable>
             ),
             headerRight: () => (
@@ -112,7 +112,7 @@ const App: () => Node = () => {
             headerTitle: "",
             headerLeft: () => (
               <Pressable onPress={() => { navigation.goBack(); }}>
-                <SFSymbol name="xmark" scale="large" color={is_dark ? "#FFFFFF" : "#337AB7"} size={16} resizeMode="center" style={is_dark ? [ styles.navbarCloseIcon, styles.dark.navbarCloseIcon ] : styles.navbarCloseIcon} />                         
+                <Icon name="close" color={is_dark ? "#FFFFFF" : "#337AB7"} size={16} style={is_dark ? [ styles.navbarCloseIcon, styles.dark.navbarCloseIcon ] : styles.navbarCloseIcon} />
               </Pressable>
             )
           })} />

--- a/App.js
+++ b/App.js
@@ -39,7 +39,7 @@ const App: () => Node = () => {
   		<Stack.Navigator>
   			<Stack.Group>
   				<Stack.Screen name="Home" component={HomeScreen} options={{
-  					headerTitle: "",
+  					title: "",
   					headerLeft: () => (
   						<Image style={styles.profileIcon} source={{ uri: "https://micro.blog/images/blank_avatar.png" }} />
   					),
@@ -52,7 +52,7 @@ const App: () => Node = () => {
   					)					
   				}} />
   				<Stack.Screen name="Details" component={BookDetailsScreen} options={({ navigation, route }) => ({
-  					headerTitle: "",
+  					title: "",
   					headerLeft: () => (
   						<Pressable onPress={() => { navigation.goBack(); }}>
                           <Icon name="navbar-back" color={is_dark ? "#FFFFFF" : "#337AB7"} size={16} style={styles.navbarBackIcon} />
@@ -67,7 +67,7 @@ const App: () => Node = () => {
   			</Stack.Group>
   			<Stack.Group screenOptions={{ presentation: "modal" }}>
   				<Stack.Screen name="Post" component={PostScreen} options={({ navigation, route }) => ({
-            headerTitle: "",
+            title: "",
             headerLeft: () => (
               <Pressable onPress={() => { navigation.goBack(); }}>
                 <Icon name="close" color={is_dark ? "#FFFFFF" : "#337AB7"} size={16} style={is_dark ? [ styles.navbarCloseIcon, styles.dark.navbarCloseIcon ] : styles.navbarCloseIcon} />
@@ -80,7 +80,7 @@ const App: () => Node = () => {
             )
           })} />
           <Stack.Screen name="SignIn" component={SignInScreen} options={({ navigation, route }) => ({
-            headerTitle: "",
+            title: "",
             headerRight: () => (
               <Pressable onPress={() => { }}>
                 <Text style={is_dark ? [ styles.navbarSubmit, styles.dark.navbarSubmit ] : styles.navbarSubmit}>Sign In</Text>
@@ -88,7 +88,7 @@ const App: () => Node = () => {
             )
           })} />
           <Stack.Screen name="Blogs" component={BlogsScreen} options={({ navigation, route }) => ({
-            headerTitle: "Blogs",
+            title: "Blogs",
             headerLeft: () => (
               <Pressable onPress={() => { navigation.goBack(); }}>
                 <Icon name="close" color={is_dark ? "#FFFFFF" : "#337AB7"} size={16} style={is_dark ? [ styles.navbarCloseIcon, styles.dark.navbarCloseIcon ] : styles.navbarCloseIcon} />
@@ -96,7 +96,7 @@ const App: () => Node = () => {
             )
           })} />
           <Stack.Screen name="Profile" component={ProfileScreen} options={({ navigation, route }) => ({
-            headerTitle: "",
+            title: "",
             headerLeft: () => (
               <Pressable onPress={() => { navigation.goBack(); }}>
                 <Icon name="close" color={is_dark ? "#FFFFFF" : "#337AB7"} size={16} style={is_dark ? [ styles.navbarCloseIcon, styles.dark.navbarCloseIcon ] : styles.navbarCloseIcon} />
@@ -109,7 +109,7 @@ const App: () => Node = () => {
             )
           })} />
           <Stack.Screen name="External" component={ExternalScreen} options={({ navigation, route }) => ({
-            headerTitle: "",
+            title: "",
             headerLeft: () => (
               <Pressable onPress={() => { navigation.goBack(); }}>
                 <Icon name="close" color={is_dark ? "#FFFFFF" : "#337AB7"} size={16} style={is_dark ? [ styles.navbarCloseIcon, styles.dark.navbarCloseIcon ] : styles.navbarCloseIcon} />

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -225,3 +225,10 @@ task copyDownloadableDepsToLibs(type: Copy) {
 }
 
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
+
+// Configuration for react-native-vector-icons
+// We're only using Google's Community Material Icons
+project.ext.vectoricons = [
+    iconFontNames: ['MaterialCommunityIcons.ttf']
+]
+apply from: "../../node_modules/react-native-vector-icons/fonts.gradle"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react-native-gesture-handler": "^2.2.0",
     "react-native-safe-area-context": "^3.3.2",
     "react-native-screens": "^3.11.0",
-    "react-native-sfsymbols": "^1.2.0"
+    "react-native-sfsymbols": "^1.2.0",
+    "react-native-vector-icons": "^9.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/src/HomeScreen.js
+++ b/src/HomeScreen.js
@@ -11,7 +11,7 @@ import { RectButton } from 'react-native-gesture-handler';
 import { keys, errors } from "./Constants";
 import styles from "./Styles";
 import epilogueStorage from "./Storage";
-import { SFSymbol } from "./SFSymbols";
+import { Icon } from "./Icon";
 
 export function HomeScreen({ navigation }) {
 	const is_dark = (useColorScheme() == "dark");
@@ -302,7 +302,7 @@ export function HomeScreen({ navigation }) {
 				actions = {items}
 				>
 					<View style={styles.navbarBookshelf}>
-						<SFSymbol name="books.vertical" scale="large" color={is_dark ? "#FFFFFF" : "#337AB7"} size={16} resizeMode="center" style={is_dark ? [ styles.navbarBookshelfIcon, styles.dark.navbarBookshelfIcon ] : styles.navbarBookshelfIcon} />                         
+						<Icon name="bookshelf" color={is_dark ? "#FFFFFF" : "#337AB7"} size={18} style={is_dark ? [ styles.navbarBookshelfIcon, styles.dark.navbarBookshelfIcon ] : styles.navbarBookshelfIcon} />
 						<Text style={is_dark ? [ styles.navbarBookshelfTitle, styles.dark.navbarBookshelfTitle ] : styles.navbarBookshelfTitle}>{currentTitle}</Text>
 					</View>
 				</MenuView>

--- a/src/Icon.tsx
+++ b/src/Icon.tsx
@@ -1,0 +1,40 @@
+import React, { Component, useState } from "react";
+import { View, Text, Platform } from "react-native";
+import AndroidIcon from 'react-native-vector-icons/MaterialCommunityIcons';
+import { SFSymbol } from "./SFSymbols";
+
+// For Icons, we use SF Symbols on iOS and Google's Material Design Icons on
+// Android. The IconNames variable below takes a generic name and maps to the
+// name of the icon on each platform.
+//
+// To find SF Symbols, you can use the SF Symbols browser on the App Store.
+// To find Material icons, use the browser here: https://materialdesignicons.com
+
+const IconNames = {
+  "publish": { ios: "square.and.pencil", android: "notebook-edit-outline" },
+  "navbar-back": { ios: "chevron.left", android: "arrow-left" },
+  "close": { ios: "xmark", android: "close" },
+  "bookshelf": { ios: "books.vertical", android: "bookshelf" }
+}
+
+export const Icon = (props) => {
+  const name = IconNames[props.name]?.[Platform.OS];
+  if (!name) {
+    throw new Error("Icon name not found in IconNames map. You need to define the icon names for iOS and Android in the Icon component file.");
+  }
+
+  const style = {
+    width: props.size,
+    height: props.size,
+    textAlignVertical: "center",
+    textAlign: "center",
+    ...props.style,
+  };
+
+  if (Platform.OS === 'android') {
+    return <AndroidIcon {...props} size={props.size + 2} name={name} style={style} />
+  }
+  if (Platform.OS === 'ios') {
+    return <SFSymbol {...props} name={name} style={style} />
+  }
+};

--- a/src/Styles.js
+++ b/src/Styles.js
@@ -12,16 +12,12 @@ export default StyleSheet.create({
 	},
 	navbarBookshelf: {
 		flexDirection: "row",
-		marginTop: 4
 	},
 	navbarBookshelfIcon: {
-		width: 25,
-		height: 25,
-		tintColor: "#337AB7",
+		color: "#337AB7",
+		marginRight: 5,
 	},
 	navbarBookshelfTitle: {
-		paddingTop: 5,
-		paddingLeft: 5,
 		color: "#337AB7",
 	},
 	item: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2097,6 +2097,15 @@ cliui@^6.0.0:
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
 
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
+
 clone-deep@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz"
@@ -3061,7 +3070,7 @@ gensync@^1.0.0-beta.2:
   resolved "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
-get-caller-file@^2.0.1:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -5389,6 +5398,14 @@ react-native-sfsymbols@^1.2.0:
   resolved "https://registry.npmjs.org/react-native-sfsymbols/-/react-native-sfsymbols-1.2.0.tgz"
   integrity sha512-IQIqpw13eB7OeWl5hndefyWHdjfNPWIbxawd4FSpw7NMAmRnDUCt08t5MZv83IEMaExdt3mIbYuSWmuxjicMJA==
 
+react-native-vector-icons@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-9.1.0.tgz#52eaa205f5954d567b7048eb93d58ac854a2c59e"
+  integrity sha512-2AHZ/h9d/+rC0odz+OwbGNlc1Lik/pHhSixn4HfC8RtQ8CxfSBZ6gg7bTLcZhdSvZN+ZEGi30Fj+ZnOSQy+smg==
+  dependencies:
+    prop-types "^15.7.2"
+    yargs "^16.1.1"
+
 react-native@0.67.2:
   version "0.67.2"
   resolved "https://registry.npmjs.org/react-native/-/react-native-0.67.2.tgz"
@@ -6661,6 +6678,15 @@ wrap-ansi@^6.2.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
@@ -6752,6 +6778,11 @@ y18n@^4.0.0:
   resolved "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz"
   integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
 
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
 yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
@@ -6764,6 +6795,11 @@ yargs-parser@^18.1.2:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
+
+yargs-parser@^20.2.2:
+  version "20.2.9"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
+  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
 yargs@^15.1.0, yargs@^15.3.1, yargs@^15.4.1:
   version "15.4.1"
@@ -6781,3 +6817,16 @@ yargs@^15.1.0, yargs@^15.3.1, yargs@^15.4.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yargs@^16.1.1:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"


### PR DESCRIPTION
This PR sets up infrastructure for handling icons on Android. It:

1. Installs `react-native-vector-icons` to support the [Google Community Material Design iconset](https://materialdesignicons.com). We’re configured to only use that one iconset. This should limit the bundle size increase to just the one font.

2. Adds an abstract `<Icon>` component that allows us to define a semantic icon name and then provide an equivalent for both iOS and Android. The wonkiest part of this is the magic number size adjustment for the Android icon, but it seems like in practice they’re about two pixels smaller than the iOS counterpart.

3. The app was set to override the title for navigation with the `headerTitle` property, [but the correct property](https://reactnavigation.org/docs/headers/#setting-the-header-title) is `title`. I changed this so that the titles don’t show on Android.

Example screenshots:

<img width="273" alt="image" src="https://user-images.githubusercontent.com/69549/156893132-4254c806-07aa-433b-a0c0-1dca4fbcac74.png">

<img width="170" alt="image" src="https://user-images.githubusercontent.com/69549/156893154-4117e241-ce1d-475a-879b-5aacab0aca2f.png">

<img width="441" alt="image" src="https://user-images.githubusercontent.com/69549/156893237-7bd46789-c22a-41c5-b7c5-3a3fa0b5ccda.png">

<img width="360" alt="image" src="https://user-images.githubusercontent.com/69549/156893240-8e7d5631-5f54-432f-a5af-47154e71e04b.png">

<img width="445" alt="image" src="https://user-images.githubusercontent.com/69549/156893251-2ccca834-875c-48f3-bfc8-2f5c0d550c88.png">

<img width="337" alt="image" src="https://user-images.githubusercontent.com/69549/156893258-57929937-4a50-44a2-83cf-8cd96055cdaf.png">
