### PR TITLE
Refactor styles to use custom hook

### DIFF
--- a/App.js
+++ b/App.js
@@ -7,7 +7,7 @@ import { MenuView } from "@react-native-menu/menu";
 import "react-native-gesture-handler"
 
 import { keys } from "./src/Constants";
-import styles from "./src/Styles";
+import { useEpilogueStyle } from './src/hooks/useEpilogueStyle';
 import epilogueStorage from "./src/Storage";
 import { Icon } from "./src/Icon";
 
@@ -29,6 +29,7 @@ const EpilogueDarkTheme = {
 };
 
 const App: () => Node = () => {	
+  const styles = useEpilogueStyle()
   const is_dark = (useColorScheme() == "dark");
 
   LogBox.ignoreAllLogs();
@@ -70,12 +71,12 @@ const App: () => Node = () => {
             title: "",
             headerLeft: () => (
               <Pressable onPress={() => { navigation.goBack(); }}>
-                <Icon name="close" color={is_dark ? "#FFFFFF" : "#337AB7"} size={16} style={is_dark ? [ styles.navbarCloseIcon, styles.dark.navbarCloseIcon ] : styles.navbarCloseIcon} />
+                <Icon name="close" color={is_dark ? "#FFFFFF" : "#337AB7"} size={16} style={styles.navbarCloseIcon} />
               </Pressable>
             ),
             headerRight: () => (
               <Pressable onPress={() => { }}>
-                <Text style={is_dark ? [ styles.navbarSubmit, styles.dark.navbarSubmit ] : styles.navbarSubmit}>Post</Text>
+                <Text style={styles.navbarSubmit}>Post</Text>
               </Pressable>
             )
           })} />
@@ -83,7 +84,7 @@ const App: () => Node = () => {
             title: "Blogs",
             headerLeft: () => (
               <Pressable onPress={() => { navigation.goBack(); }}>
-                <Icon name="close" color={is_dark ? "#FFFFFF" : "#337AB7"} size={16} style={is_dark ? [ styles.navbarCloseIcon, styles.dark.navbarCloseIcon ] : styles.navbarCloseIcon} />
+                <Icon name="close" color={is_dark ? "#FFFFFF" : "#337AB7"} size={16} style={styles.navbarCloseIcon} />
               </Pressable>
             )
           })} />
@@ -91,12 +92,12 @@ const App: () => Node = () => {
             title: "",
             headerLeft: () => (
               <Pressable onPress={() => { navigation.goBack(); }}>
-                <Icon name="close" color={is_dark ? "#FFFFFF" : "#337AB7"} size={16} style={is_dark ? [ styles.navbarCloseIcon, styles.dark.navbarCloseIcon ] : styles.navbarCloseIcon} />
+                <Icon name="close" color={is_dark ? "#FFFFFF" : "#337AB7"} size={16} style={styles.navbarCloseIcon} />
               </Pressable>
             ),
             headerRight: () => (
               <Pressable onPress={() => { }}>
-                <Text style={is_dark ? [ styles.navbarSubmit, styles.dark.navbarSubmit ] : styles.navbarSubmit}>Sign Out</Text>
+                <Text style={styles.navbarSubmit}>Sign Out</Text>
               </Pressable>
             )
           })} />
@@ -104,7 +105,7 @@ const App: () => Node = () => {
             title: "",
             headerLeft: () => (
               <Pressable onPress={() => { navigation.goBack(); }}>
-                <Icon name="close" color={is_dark ? "#FFFFFF" : "#337AB7"} size={16} style={is_dark ? [ styles.navbarCloseIcon, styles.dark.navbarCloseIcon ] : styles.navbarCloseIcon} />
+                <Icon name="close" color={is_dark ? "#FFFFFF" : "#337AB7"} size={16} style={styles.navbarCloseIcon} />
               </Pressable>
             )
           })} />

--- a/src/BlogsScreen.js
+++ b/src/BlogsScreen.js
@@ -1,14 +1,14 @@
 import React, { useState } from "react";
 import type { Node } from "react";
-import { FlatList, ActivityIndicator, useColorScheme, Pressable, StyleSheet, Text, View } from "react-native";
+import { FlatList, ActivityIndicator, Pressable, StyleSheet, Text, View } from "react-native";
 import { NavigationContainer } from "@react-navigation/native";
 
 import { keys } from "./Constants";
-import styles from "./Styles";
+import { useEpilogueStyle } from "./hooks/useEpilogueStyle";
 import epilogueStorage from "./Storage";
 
 export function BlogsScreen({ navigation }) {
-	const is_dark = (useColorScheme() == "dark");
+	const styles = useEpilogueStyle()
 	const [ blogs, setBlogs ] = useState([]);
 	
 	React.useEffect(() => {
@@ -73,12 +73,12 @@ export function BlogsScreen({ navigation }) {
 	}
 	
 	return (
-		<View style={is_dark ? [ styles.blogListContainer, styles.dark.blogListContainer ] : styles.blogListContainer}>
+		<View style={styles.blogListContainer}>
 			<FlatList
 			data = {blogs}
 			renderItem = { ({item}) => 
-			<Pressable style={is_dark ? [ styles.blogListItem, styles.dark.blogListItem ] : styles.blogListItem} onPress={() => { onSelectBlog(item) }}>
-				<Text style={is_dark ? [ styles.blogListName, styles.dark.blogListName ] : styles.blogListName}>{item.name}</Text>
+			<Pressable style={styles.blogListItem} onPress={() => { onSelectBlog(item) }}>
+				<Text style={styles.blogListName}>{item.name}</Text>
 			</Pressable>
 			}
 			keyExtractor = { item => item.id }

--- a/src/BookDetailsScreen.js
+++ b/src/BookDetailsScreen.js
@@ -1,16 +1,16 @@
 import React, { useState } from "react";
 import type { Node } from "react";
-import { ActivityIndicator, useColorScheme, Pressable, Button, Image, FlatList, StyleSheet, Text, SafeAreaView, View, ScrollView } from "react-native";
+import { ActivityIndicator, Pressable, Button, Image, FlatList, StyleSheet, Text, SafeAreaView, View, ScrollView } from "react-native";
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { MenuView } from "@react-native-menu/menu";
 
 import { keys } from "./Constants";
-import styles from "./Styles";
+import { useEpilogueStyle } from "./hooks/useEpilogueStyle";
 import epilogueStorage from "./Storage";
 
 export function BookDetailsScreen({ route, navigation }) {
-	const is_dark = (useColorScheme() == "dark");
+	const styles = useEpilogueStyle()
 	const [ data, setData ] = useState();
 	const [ progressAnimating, setProgressAnimating ] = useState(false);
 	const { id, isbn, title, image, author, description, bookshelves, current_bookshelf, is_search } = route.params;
@@ -84,16 +84,16 @@ export function BookDetailsScreen({ route, navigation }) {
 	}
 
 	return (
-		<ScrollView style={is_dark ? [ styles.bookDetailsScroll, styles.dark.bookDetailsScroll ] : styles.bookDetailsScroll}>
-			<View style={is_dark ? [ styles.container, styles.dark.container ] : styles.container}>
-				<View style={is_dark ? [ styles.bookDetails, styles.dark.bookDetails ] : styles.bookDetails}>
+		<ScrollView style={styles.bookDetailsScroll}>
+			<View style={styles.container}>
+				<View style={styles.bookDetails}>
 					<Image style={styles.bookDetailsCover} source={{ uri: image.replace("http://", "https://") }} />
-					<Text style={is_dark ? [ styles.bookDetailsTitle, styles.dark.bookDetailsTitle ] : styles.bookDetailsTitle}>{title}</Text>
-					<Text style={is_dark ? [ styles.bookDetailsAuthor, styles.dark.bookDetailsAuthor ] : styles.bookDetailsAuthor}>{author}</Text>
+					<Text style={styles.bookDetailsTitle}>{title}</Text>
+					<Text style={styles.bookDetailsAuthor}>{author}</Text>
 				</View>
 				<View style={styles.bookDetailsBookshelves}>
 					<View style={styles.bookDetailsAddBar}>
-					<Text style={is_dark ? [ styles.bookDetailsAddTo, styles.dark.bookDetailsAddTo ] : styles.bookDetailsAddTo}>Add to bookshelf...</Text>
+					<Text style={styles.bookDetailsAddTo}>Add to bookshelf...</Text>
 					<ActivityIndicator style={styles.BookDetailsProgress} size="small" animating={progressAnimating} />
 				</View>
 				{
@@ -102,22 +102,22 @@ export function BookDetailsScreen({ route, navigation }) {
 							styles.bookDetailsButton,
 							{
 								backgroundColor: pressed ? 
-								(is_dark ? styles.dark.bookDetailsButton.pressed.backgroundColor : styles.bookDetailsButton.pressed.backgroundColor) : 
-								(is_dark ? styles.dark.bookDetailsButton.backgroundColor : styles.bookDetailsButton.backgroundColor)
+								styles.bookDetailsButton.pressed.backgroundColor : 
+								styles.bookDetailsButton.backgroundColor
 							},
 						]}>
-							<Text style={is_dark ? [ styles.bookDetailsBookshelfTitle, styles.dark.bookDetailsBookshelfTitle ] : styles.bookDetailsBookshelfTitle}>{shelf.title}</Text>
-							<Text style={is_dark ? [ styles.bookDetailsBookshelfCount, styles.dark.bookDetailsBookshelfCount ] : styles.bookDetailsBookshelfCount}>{shelf.books_count}</Text>
+							<Text style={styles.bookDetailsBookshelfTitle}>{shelf.title}</Text>
+							<Text style={styles.bookDetailsBookshelfCount}>{shelf.books_count}</Text>
 						</Pressable>
 					))
 				}
 				</View>
 				<View style={
 					description.length > 0 ?
-					(is_dark ? [ styles.bookDetailsMore, styles.dark.bookDetailsMore ] : styles.bookDetailsMore) :
+					(styles.bookDetailsMore) :
 					styles.bookDetailsNoDescription
 					}>
-					<Text style={is_dark ? [ styles.bookDetailsDescription, styles.dark.bookDetailsDescription ] : styles.bookDetailsDescription}>{description}</Text>
+					<Text style={styles.bookDetailsDescription}>{description}</Text>
 				</View>
 			</View>
 		</ScrollView>

--- a/src/ExternalScreen.js
+++ b/src/ExternalScreen.js
@@ -1,15 +1,15 @@
 import React, { useState } from "react";
 import type { Node } from "react";
-import { Linking, Alert, TextInput, ActivityIndicator, useColorScheme, Pressable, Button, Image, StyleSheet, Text, SafeAreaView, View } from "react-native";
+import { Linking, Alert, TextInput, ActivityIndicator, Pressable, Button, Image, StyleSheet, Text, SafeAreaView, View } from "react-native";
 import { NavigationContainer } from "@react-navigation/native";
 import { DOMParser } from "@xmldom/xmldom";
 
 import { keys, errors } from "./Constants";
-import styles from "./Styles";
+import { useEpilogueStyle } from './hooks/useEpilogueStyle';
 import epilogueStorage from "./Storage";
 
 export function ExternalScreen({ navigation }) {
-	const is_dark = (useColorScheme() == "dark");
+	const styles = useEpilogueStyle()
 	const [ url, setURL ] = useState();
 	
 	React.useEffect(() => {
@@ -143,9 +143,9 @@ export function ExternalScreen({ navigation }) {
 	}
 		
 	return (
-		<View style={is_dark ? [ styles.container, styles.dark.container ] : styles.container}>
-			<Text style={is_dark ? [ styles.micropubIntro, styles.dark.micropubIntro ] : styles.micropubIntro} >Post to an external blog via Micropub:</Text>
-			<TextInput style={is_dark ? [ styles.micropubURL, styles.dark.micropubURL ] : styles.micropubURL} value={url} onChangeText={setURL} onEndEditing={onSendURL} returnKeyType="done" placeholder="Your blog URL" autoCapitalize="none" autoCorrect={false} autoFocus={true} />
+		<View style={styles.container}>
+			<Text style={styles.micropubIntro} >Post to an external blog via Micropub:</Text>
+			<TextInput style={styles.micropubURL} value={url} onChangeText={setURL} onEndEditing={onSendURL} returnKeyType="done" placeholder="Your blog URL" autoCapitalize="none" autoCorrect={false} autoFocus={true} />
 		</View>
 	);
 }

--- a/src/HomeScreen.js
+++ b/src/HomeScreen.js
@@ -9,11 +9,12 @@ import { Animated } from 'react-native';
 import { RectButton } from 'react-native-gesture-handler';
 
 import { keys, errors } from "./Constants";
-import styles from "./Styles";
+import { useEpilogueStyle } from './hooks/useEpilogueStyle';
 import epilogueStorage from "./Storage";
 import { Icon } from "./Icon";
 
 export function HomeScreen({ navigation }) {
+	const styles = useEpilogueStyle()
 	const is_dark = (useColorScheme() == "dark");
 	const [ books, setBooks ] = useState();
 	const [ bookshelves, setBookshelves ] = useState([]);
@@ -302,8 +303,8 @@ export function HomeScreen({ navigation }) {
 				actions = {items}
 				>
 					<View style={styles.navbarBookshelf}>
-						<Icon name="bookshelf" color={is_dark ? "#FFFFFF" : "#337AB7"} size={18} style={is_dark ? [ styles.navbarBookshelfIcon, styles.dark.navbarBookshelfIcon ] : styles.navbarBookshelfIcon} />
-						<Text style={is_dark ? [ styles.navbarBookshelfTitle, styles.dark.navbarBookshelfTitle ] : styles.navbarBookshelfTitle}>{currentTitle}</Text>
+						<Icon name="bookshelf" color={is_dark ? "#FFFFFF" : "#337AB7"} size={18} style={styles.navbarBookshelfIcon} />
+						<Text style={styles.navbarBookshelfTitle}>{currentTitle}</Text>
 					</View>
 				</MenuView>
 			)
@@ -497,18 +498,18 @@ export function HomeScreen({ navigation }) {
 	}
 
 	return (
-		<View style={is_dark ? [ styles.container, styles.dark.container ] : styles.container}>
-			<TextInput style={is_dark ? [ styles.searchField, styles.dark.searchField ] : styles.searchField} onChangeText={onChangeSearch} onEndEditing={onRunSearch} returnKeyType="search" placeholder="Search for books to add" clearButtonMode="always" />
+		<View style={styles.container}>
+			<TextInput style={styles.searchField} onChangeText={onChangeSearch} onEndEditing={onRunSearch} returnKeyType="search" placeholder="Search for books to add" clearButtonMode="always" />
 			<FlatList
 				data = {books}
 				renderItem = { ({item}) => 
 				<BookSwipeableRow book={item.id}>
 					<Pressable onPress={() => { onShowBookPressed(item) }}>
-						<View style={is_dark ? [ styles.item, styles.dark.item ] : styles.item}>
+						<View style={styles.item}>
 							<Image style={styles.bookCover} source={{ uri: item.image.replace("http://", "https://") }} />
 							<View style={styles.bookItem}>
-								<Text style={is_dark ? [ styles.bookTitle, styles.dark.bookTitle ] : styles.bookTitle} ellipsizeMode="tail" numberOfLines={2}>{item.title}</Text>
-								<Text style={is_dark ? [ styles.bookAuthor, styles.dark.bookAuthor ] : styles.bookAuthor}>{item.author}</Text>
+								<Text style={styles.bookTitle} ellipsizeMode="tail" numberOfLines={2}>{item.title}</Text>
+								<Text style={styles.bookAuthor}>{item.author}</Text>
 							</View>
 						</View>
 					</Pressable>

--- a/src/PostScreen.js
+++ b/src/PostScreen.js
@@ -1,14 +1,14 @@
 import React, { useState } from "react";
 import type { Node } from "react";
-import { TextInput, ActivityIndicator, useColorScheme, Pressable, Button, Image, StyleSheet, Text, SafeAreaView, View } from "react-native";
+import { TextInput, ActivityIndicator, Pressable, Button, Image, StyleSheet, Text, SafeAreaView, View } from "react-native";
 import { NavigationContainer } from "@react-navigation/native";
 
 import { keys } from "./Constants";
-import styles from "./Styles";
+import { useEpilogueStyle } from './hooks/useEpilogueStyle';
 import epilogueStorage from "./Storage";
 
 export function PostScreen({ navigation }) {
-	const is_dark = (useColorScheme() == "dark");
+	const styles = useEpilogueStyle()
 	const [ text, setText ] = useState();
 	const [ blogID, setBlogID ] = useState();
 	const [ blogName, setBlogName ] = useState();
@@ -39,7 +39,7 @@ export function PostScreen({ navigation }) {
 		navigation.setOptions({
 			headerRight: () => (
 			  <Pressable onPress={() => { onSendPost(); }}>
-				<Text style={is_dark ? [ styles.navbarSubmit, styles.dark.navbarSubmit ] : styles.navbarSubmit}>Post</Text>
+				<Text style={styles.navbarSubmit}>Post</Text>
 			  </Pressable>
 			)
 		});		
@@ -113,13 +113,13 @@ export function PostScreen({ navigation }) {
 	}
 	
 	return (
-		<View style={is_dark ? [ styles.postTextBox, styles.dark.postTextBox ] : styles.postTextBox}>
-			<Pressable style={is_dark ? [ styles.postHostnameBar, styles.dark.postHostnameBar ] : styles.postHostnameBar} onPress={onShowBlogs}>
+		<View style={styles.postTextBox}>
+			<Pressable style={styles.postHostnameBar} onPress={onShowBlogs}>
 				<Text style={styles.postHostnameLeft}></Text>
-				<Text style={is_dark ? [ styles.postHostnameText, styles.dark.postHostnameText ] : styles.postHostnameText}>{blogName}</Text>
+				<Text style={styles.postHostnameText}>{blogName}</Text>
 				<ActivityIndicator style={styles.postHostnameProgress} size="small" animating={progressAnimating} />
 			</Pressable>
-			<TextInput style={is_dark ? [ styles.postTextInput, styles.dark.postTextInput ] : styles.postTextInput} value={text} onChangeText={onChangeText} multiline={true} />
+			<TextInput style={styles.postTextInput} value={text} onChangeText={onChangeText} multiline={true} />
 		</View>
 	);
 }

--- a/src/ProfileScreen.js
+++ b/src/ProfileScreen.js
@@ -1,14 +1,14 @@
 import React, { useState } from "react";
 import type { Node } from "react";
-import { Alert, TextInput, ActivityIndicator, useColorScheme, Pressable, Button, Image, StyleSheet, Text, SafeAreaView, View } from "react-native";
+import { Alert, TextInput, ActivityIndicator, Pressable, Button, Image, StyleSheet, Text, SafeAreaView, View } from "react-native";
 import { NavigationContainer } from "@react-navigation/native";
 
 import { keys } from "./Constants";
-import styles from "./Styles";
+import { useEpilogueStyle } from './hooks/useEpilogueStyle';
 import epilogueStorage from "./Storage";
 
 export function ProfileScreen({ navigation }) {
-	const is_dark = (useColorScheme() == "dark");
+	const styles = useEpilogueStyle()
 	const [ username, setUsername ] = useState("");
 	const [ hostname, setHostname ] = useState("Micro.blog");
 	
@@ -79,22 +79,22 @@ export function ProfileScreen({ navigation }) {
 		navigation.setOptions({
 			headerRight: () => (
 			  <Pressable onPress={() => { onSignOut(); }}>
-			  	<Text style={is_dark ? [ styles.navbarSubmit, styles.dark.navbarSubmit ] : styles.navbarSubmit}>Sign Out</Text>
+			  	<Text style={styles.navbarSubmit}>Sign Out</Text>
 			  </Pressable>
 			)
 		});		
 	}
 	
 	return (
-		<View style={is_dark ? [ styles.container, styles.dark.container ] : styles.container}>
-			<View style={is_dark ? [ styles.profilePane, styles.dark.profilePane ] : styles.profilePane}>
+		<View style={styles.container}>
+			<View style={styles.profilePane}>
 				<Image style={styles.profilePhoto} source={{ uri: "https://micro.blog/" + username + "/avatar.jpg" }} />
-				<Text style={is_dark ? [ styles.profileUsername, styles.dark.profileUsername ] : styles.profileUsername}>@{username}</Text>
+				<Text style={styles.profileUsername}>@{username}</Text>
 			</View>
 			<View style={styles.micropubPane}>
-				<Text style={is_dark ? [ styles.micropubHostname, styles.dark.micropubHostname ] : styles.micropubHostname}>Posting to: {hostname}</Text>
-				<Pressable style={is_dark ? [ styles.micropubButton, styles.dark.micropubButton ] : styles.micropubButton} onPress={() => { onChangePressed(); }}>
-					<Text style={is_dark ? [ styles.micropubButtonTitle, styles.dark.micropubButtonTitle ] : styles.micropubButtonTitle} accessibilityLabel="change posting blog">Change...</Text>
+				<Text style={styles.micropubHostname}>Posting to: {hostname}</Text>
+				<Pressable style={styles.micropubButton} onPress={() => { onChangePressed(); }}>
+					<Text style={styles.micropubButtonTitle} accessibilityLabel="change posting blog">Change...</Text>
 				</Pressable>
 			</View>
 		</View>

--- a/src/SignInScreen.js
+++ b/src/SignInScreen.js
@@ -1,12 +1,13 @@
 import React, { useState } from "react";
-import { Button, TextInput, useColorScheme, Pressable, Text, View, ScrollView, Image } from "react-native";
+import { TextInput, Pressable, Text, View, Image } from "react-native";
 
 import { keys } from "./Constants";
+import { useEpilogueStyle } from './hooks/useEpilogueStyle';
 import styles from "./Styles";
 import epilogueStorage from "./Storage";
 
 export function SignInScreen({ navigation }) {
-	const is_dark = (useColorScheme() == "dark");
+	const styles = useEpilogueStyle()
 	const [ email, setEmail ] = useState();
 	const [ emailSent, setEmailSent ] = useState(false);
 
@@ -15,7 +16,7 @@ export function SignInScreen({ navigation }) {
 			headerRight: () => (
 			!emailSent &&
 			  <Pressable onPress={() => { onSendEmail(); }}>
-				<Text style={is_dark ? [ styles.navbarSubmit, styles.dark.navbarSubmit ] : styles.navbarSubmit}>Sign In</Text>
+				<Text style={styles.navbarSubmit}>Sign In</Text>
 			  </Pressable>
 			),
 		});
@@ -49,27 +50,27 @@ export function SignInScreen({ navigation }) {
 	
 	return (
 		emailSent === false ? (
-			<View style={is_dark ? [styles.signIn, styles.dark.signIn] : styles.signIn}>
+			<View style={styles.signIn}>
 				<View style={styles.signInHeader}>
 					<Image style={styles.signInImage} source={require("../images/welcome-logo.png")} />
-					<Text style={is_dark ? [styles.signInTextHeader, styles.dark.signInText] : styles.signInTextHeader}>
+					<Text style={styles.signInTextHeader}>
 						Epilogue is a companion app for Micro.blog. It uses Micro.blog’s bookshelves to help you track which books you are reading or want to read. You can blog directly from Epilogue.
 					</Text>
 				</View>
-				<Text style={is_dark ? [styles.signInText, styles.dark.signInText, { fontWeight: "500" }] : [styles.signInText, { fontWeight: "500" }]}>
+				<Text style={[styles.signInText, { fontWeight: "500" }]}>
 					Enter your Micro.blog account email address and you'll receive a link to sign in:
 				</Text>
-				<TextInput style={is_dark ? [styles.signInInput, styles.dark.signInInput] : styles.signInInput} value={email} onChangeText={setEmail} onEndEditing={onSendEmail} returnKeyType="done" placeholder="email@email.com" keyboardType="email-address" autoCapitalize="none" autoCorrect={false} autoFocus={true} />
+				<TextInput style={styles.signInInput} value={email} onChangeText={setEmail} onEndEditing={onSendEmail} returnKeyType="done" placeholder="email@email.com" keyboardType="email-address" autoCapitalize="none" autoCorrect={false} autoFocus={true} />
 			</View>
 		) : (
-			<View style={is_dark ? [styles.signIn, styles.dark.signIn] : styles.signIn}>
+			<View style={styles.signIn}>
 				<View style={styles.signInHeader}>
 					<Image style={styles.signInImage} source={require("../images/welcome-logo.png")} />
 				</View>
-				<Text style={is_dark ? [styles.signInText, styles.dark.signInText] : styles.signInText}>
+				<Text style={styles.signInText}>
 					We sent an email to: <Text style={{ fontWeight: "600" }}>{email}</Text>
 				</Text>
-				<Text style={is_dark ? [styles.signInText, styles.dark.signInText] : styles.signInText}>
+				<Text style={styles.signInText}>
 					Check your email on this device for a link to finish signing in.
 				</Text>
 				<Pressable onPress={() => { setEmailSent(false); setEmail(undefined); }}>

--- a/src/SignInScreen.js
+++ b/src/SignInScreen.js
@@ -3,7 +3,6 @@ import { TextInput, Pressable, Text, View, Image } from "react-native";
 
 import { keys } from "./Constants";
 import { useEpilogueStyle } from './hooks/useEpilogueStyle';
-import styles from "./Styles";
 import epilogueStorage from "./Storage";
 
 export function SignInScreen({ navigation }) {

--- a/src/Styles.js
+++ b/src/Styles.js
@@ -1,5 +1,11 @@
 import { StyleSheet } from "react-native";
 
+export const light = StyleSheet.create({
+});
+
+export const dark = StyleSheet.create({
+});
+
 export default StyleSheet.create({
 	container: {
 		flex: 1,

--- a/src/Styles.js
+++ b/src/Styles.js
@@ -1,12 +1,6 @@
 import { StyleSheet } from "react-native";
 
 export const light = StyleSheet.create({
-});
-
-export const dark = StyleSheet.create({
-});
-
-export default StyleSheet.create({
 	container: {
 		flex: 1,
 		paddingTop: 10
@@ -289,128 +283,137 @@ export default StyleSheet.create({
 	},
 	bookDetailsNoDescription: {		
 	},
-	dark: {
-		container: {
-			backgroundColor: "#212936",
-			color: "#E5E7EB"
-		},
-		bookTitle: {
-			color: "#FFFFFF"	
-		},
-		bookAuthor: {
-			color: "#777777"
-		},		
-		navbarBookshelfIcon: {
-			tintColor: "#FFFFFF"
-		},
-		navbarBookshelfTitle: {
-			color: "#FFFFFF"
-		},
-		searchField: {
-			backgroundColor: "#000000",
-			borderColor: "#555b64",
-			color: "#FFFFFF"
-		},
-		bookDetailsScroll: {
-			backgroundColor: "#212936"
-		},
-		bookDetails: {
-			borderBottomColor: "#444444"
-		},
-		bookDetailsTitle: {
-			color: "#FFFFFF"
-		},
-		bookDetailsAuthor: {
-			color: "#777777"
-		},
-		bookDetailsAddTo: {
-			color: "#FFFFFF"
-		},
-		postTextBox: {
-			backgroundColor: "#212936",
-			color: "#E5E7EB",
-			height: 2000
-		},
-		bookDetailsButton: {
-			backgroundColor: "#141723",
-			pressed: {
-				backgroundColor: "#000000"
-			}
-		},		
-		bookDetailsBookshelfTitle: {
-			color: "#FFFFFF"
-		},
-		bookDetailsBookshelfCount: {
-			color: "#777777"
-		},
-		blogListContainer: {
-			backgroundColor: "#212936",
-			color: "#E5E7EB"
-		},
-		blogListItem: {
-			borderBottomColor: "#444444"			
-		},
-		blogListName: {
-			color: "#E5E7EB"
-		},
-		postHostnameBar: {
-			backgroundColor: "#000000",
-			borderBottomColor: "#444444"
-		},
-		postHostnameText: {
-			color: "#E5E7EB"
-		},
-		postTextInput: {
-			color: "#E5E7EB"
-		},
-		navbarNewIcon: {
-			tintColor: "#FFFFFF"
-		},
-		navbarBackIcon: {
-			tintColor: "#FFFFFF"
-		},
-		navbarCloseIcon: {
-			tintColor: "#FFFFFF"
-		},
-		navbarSubmit: {
-			color: "#FFFFFF"
-		},
-		signIn: {
+});
+
+export const dark = StyleSheet.create({
+	container: {
+		backgroundColor: "#212936",
+		color: "#E5E7EB"
+	},
+	bookTitle: {
+		color: "#FFFFFF"	
+	},
+	bookAuthor: {
+		color: "#777777"
+	},		
+	navbarBookshelfIcon: {
+		tintColor: "#FFFFFF"
+	},
+	navbarBookshelfTitle: {
+		color: "#FFFFFF"
+	},
+	searchField: {
+		backgroundColor: "#000000",
+		borderColor: "#555b64",
+		color: "#FFFFFF"
+	},
+	bookDetailsScroll: {
+		backgroundColor: "#212936"
+	},
+	bookDetails: {
+		borderBottomColor: "#444444"
+	},
+	bookDetailsTitle: {
+		color: "#FFFFFF"
+	},
+	bookDetailsAuthor: {
+		color: "#777777"
+	},
+	bookDetailsAddTo: {
+		color: "#FFFFFF"
+	},
+	postTextBox: {
+		backgroundColor: "#212936",
+		color: "#E5E7EB",
+		height: 2000
+	},
+	bookDetailsButton: {
+		backgroundColor: "#141723",
+		pressed: {
 			backgroundColor: "#000000"
-		},
-		signInText: {
-			color: "#E5E7EB"
-		},
-		signInInput: {
-			borderColor: "rgba(255, 255, 255, 0.20)",
-			color: "#FFF"
-		},
-		profilePane: {
-			borderBottomColor: "#444444"
-		},
-		profileUsername: {
-			color: "#E5E7EB"
-		},
-		micropubHostname: {
-			color: "#E5E7EB"
-		},
-		micropubButton: {
-			backgroundColor: "#141723"
-		},
-		micropubButtonTitle: {
-			color: "#E5E7EB"
-		},
-		micropubIntro: {
-			color: "#E5E7EB"
-		},
-		micropubURL: {
-			color: "#E5E7EB"
-		},
-		bookDetailsMore: {
-			borderTopColor: "#444444"
-		},
-		bookDetailsDescription: {
-			color: "#E5E7EB"
 		}
+	},		
+	bookDetailsBookshelfTitle: {
+		color: "#FFFFFF"
+	},
+	bookDetailsBookshelfCount: {
+		color: "#777777"
+	},
+	blogListContainer: {
+		backgroundColor: "#212936",
+		color: "#E5E7EB"
+	},
+	blogListItem: {
+		borderBottomColor: "#444444"			
+	},
+	blogListName: {
+		color: "#E5E7EB"
+	},
+	postHostnameBar: {
+		backgroundColor: "#000000",
+		borderBottomColor: "#444444"
+	},
+	postHostnameText: {
+		color: "#E5E7EB"
+	},
+	postTextInput: {
+		color: "#E5E7EB"
+	},
+	navbarNewIcon: {
+		tintColor: "#FFFFFF"
+	},
+	navbarBackIcon: {
+		tintColor: "#FFFFFF"
+	},
+	navbarCloseIcon: {
+		tintColor: "#FFFFFF"
+	},
+	navbarSubmit: {
+		color: "#FFFFFF"
+	},
+	signIn: {
+		backgroundColor: "#000000"
+	},
+	signInText: {
+		color: "#E5E7EB"
+	},
+	signInTextHeader: {
+		color: "#E5E7EB"
+	},
+	signInInput: {
+		borderColor: "rgba(255, 255, 255, 0.20)",
+		color: "#FFF"
+	},
+	profilePane: {
+		borderBottomColor: "#444444"
+	},
+	profileUsername: {
+		color: "#E5E7EB"
+	},
+	micropubHostname: {
+		color: "#E5E7EB"
+	},
+	micropubButton: {
+		backgroundColor: "#141723"
+	},
+	micropubButtonTitle: {
+		color: "#E5E7EB"
+	},
+	micropubIntro: {
+		color: "#E5E7EB"
+	},
+	micropubURL: {
+		color: "#E5E7EB"
+	},
+	bookDetailsMore: {
+		borderTopColor: "#444444"
+	},
+	bookDetailsDescription: {
+		color: "#E5E7EB"
+	}
+});
+
+export default StyleSheet.create({
+	dark: {
 	}
 });

--- a/src/Styles.js
+++ b/src/Styles.js
@@ -15,7 +15,7 @@ export const light = StyleSheet.create({
 	},
 	navbarBookshelfIcon: {
 		color: "#337AB7",
-		marginRight: 5,
+		marginRight: 8,
 	},
 	navbarBookshelfTitle: {
 		color: "#337AB7",
@@ -410,10 +410,5 @@ export const dark = StyleSheet.create({
 	},
 	bookDetailsDescription: {
 		color: "#E5E7EB"
-	}
-});
-
-export default StyleSheet.create({
-	dark: {
 	}
 });

--- a/src/hooks/useEpilogueStyle.js
+++ b/src/hooks/useEpilogueStyle.js
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useColorScheme } from "react-native";
+import { dark, light } from "../Styles";
+
+export const useEpilogueTheme = () => {
+	const colorScheme = useColorScheme();
+	const [theme, setTheme] = useState(colorScheme === "light" ? light : dark);
+
+	useEffect(() => {
+		setTheme(colorScheme === "light" ? light : dark)
+	}, [colorScheme]);
+
+	return theme;
+}

--- a/src/hooks/useEpilogueStyle.js
+++ b/src/hooks/useEpilogueStyle.js
@@ -1,14 +1,30 @@
-import { useEffect } from "react";
-import { useColorScheme } from "react-native";
-import { dark, light } from "../Styles";
+import { useEffect, useState } from "react";
+import { useColorScheme, StyleSheet } from "react-native";
+import { light, dark } from "../Styles";
 
-export const useEpilogueTheme = () => {
+// Get all keys for both light and dark keys
+const allStyleKeys = new Set(Object.keys(light).concat(Object.keys(dark)));
+
+// Merge dark styles over light styles
+const darkMergedOnLight = StyleSheet.create(Array.from(allStyleKeys).reduce((prev, key) => {
+	if (light[key] && dark[key]) {
+		prev[key] = StyleSheet.compose(light[key], dark[key]);
+	} else if (light[key]) {
+		prev[key] = light[key]
+	} else {
+		prev[key] = dark[key]
+	}
+	return prev;
+}, {}));
+
+// Expose the correct stylesheet depending on the selected colour scheme
+export const useEpilogueStyle = () => {
 	const colorScheme = useColorScheme();
-	const [theme, setTheme] = useState(colorScheme === "light" ? light : dark);
+	const [theme, setTheme] = useState(colorScheme === "light" ? light : darkMergedOnLight);
 
 	useEffect(() => {
-		setTheme(colorScheme === "light" ? light : dark)
-	}, [colorScheme]);
+		setTheme(colorScheme === "light" ? light : darkMergedOnLight)
+	}, [colorScheme, light, darkMergedOnLight]);
 
 	return theme;
 }


### PR DESCRIPTION
This PR keeps the existing styling logic (dark mode overrides light mode styles) but refactors styling to use a custom react hook. 

This allows us to reference styles once like `<Text style={styles.foobar}>` but get the light mode styles when the user is in light mode, and the light mode styles merged with the dark mode styles when the user is in dark mode. It effectively moves the decision making from each component to an abstraction.

I think this makes styling easier to manage, but a) this is somewhat personal preference, b) I don’t know if you’re planning on using styled-components or Emotion in the future for other Micro.blog projects, so feel free to just close this if it’s not up your alley.