### PR TITLE
Tweaked sign in image, Android post icon

### DIFF
--- a/src/Icon.tsx
+++ b/src/Icon.tsx
@@ -11,7 +11,7 @@ import { SFSymbol } from "./SFSymbols";
 // To find Material icons, use the browser here: https://materialdesignicons.com
 
 const IconNames = {
-  "publish": { ios: "square.and.pencil", android: "notebook-edit-outline" },
+  "publish": { ios: "square.and.pencil", android: "pencil" },
   "navbar-back": { ios: "chevron.left", android: "arrow-left" },
   "close": { ios: "xmark", android: "close" },
   "bookshelf": { ios: "books.vertical", android: "bookshelf" }

--- a/src/Styles.js
+++ b/src/Styles.js
@@ -196,9 +196,11 @@ export const light = StyleSheet.create({
 		fontSize: 16,
 	},
 	signInImage: {
-		width: 80,
-		height: 80,
-		marginRight: 10,
+		width: 50,
+		height: 50,
+		marginTop: 15,
+		marginLeft: 5,
+		marginRight: 15,
 	},
 	signInText: {
 		fontSize: 16,


### PR DESCRIPTION
Smaller image. I plan to eventually get a new app icon, because this one doesn't look great especially at large sizes. Also changed the new post icon to `pencil` on Android.