### PR TITLE
Fixed edit items for Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -85,7 +85,7 @@ android {
         applicationId "blog.micro.epilogue"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 41
+        versionCode 43
         versionName "2.2.1"
     }
     signingConfigs {

--- a/src/screens/BookDetailsScreen.js
+++ b/src/screens/BookDetailsScreen.js
@@ -75,37 +75,37 @@ export function BookDetailsScreen({ route, navigation }) {
 			},
 		];
 		
+		var edit_actions = [];
+		var share_actions = [];
+
+		if (!is_search) {
+			edit_actions.push({
+				id: "editbook",
+				title: "Edit Title & Author"
+			});
+		}
+
+		if (!is_search) {
+			edit_actions.push({
+				id: "setopenlibrary",
+				title: "Set Cover from Open Library"
+			});
+		}
+
+		if (current_bookshelf.type == "finished") {
+			edit_actions.push({
+				id: "setfinisheddate",
+				title: "Set Finished Date"
+			});
+		}
+
+		share_actions.push({
+			id: "sharebutton",
+			title: "Share",
+			systemIcon: "square.and.arrow.up"
+		})
+
 		if (Platform.OS === "ios") {
-			var edit_actions = [];
-			var share_actions = [];
-
-			if (!is_search) {
-				edit_actions.push({
-					id: "editbook",
-					title: "Edit Title & Author"
-				});
-			}
-
-			if (!is_search) {
-				edit_actions.push({
-					id: "setopenlibrary",
-					title: "Set Cover from Open Library"
-				});
-			}
-
-			if (current_bookshelf.type == "finished") {
-				edit_actions.push({
-					id: "setfinisheddate",
-					title: "Set Finished Date"
-				});
-			}
-
-			share_actions.push({
-				id: "sharebutton",
-				title: "Share",
-				systemIcon: "square.and.arrow.up"
-			})
-
 			menu_items.push({
 				id: "edit",
 				title: "Edit Book...",
@@ -119,6 +119,15 @@ export function BookDetailsScreen({ route, navigation }) {
 				inlineChildren: true,
 				actions: share_actions
 			})
+		}
+		else {
+			menu_items.push({
+				id: "separator",
+				title: "────────────────────",
+				disabled: true
+			});
+			menu_items.push(...edit_actions);
+			menu_items.push(...share_actions);
 		}
 		
 		setMenuActions(menu_items);

--- a/src/screens/BookDetailsScreen.js
+++ b/src/screens/BookDetailsScreen.js
@@ -92,7 +92,7 @@ export function BookDetailsScreen({ route, navigation }) {
 			});
 		}
 
-		if (current_bookshelf.type == "finished") {
+		if (!is_search && current_bookshelf.type == "finished") {
 			edit_actions.push({
 				id: "setfinisheddate",
 				title: "Set Finished Date"


### PR DESCRIPTION
Context menu was half iOS-only. Also added hacky separator since visually it doesn't have the groups that iOS has.